### PR TITLE
fix logic error rejecting valid values and accepting invalid values

### DIFF
--- a/seq.c
+++ b/seq.c
@@ -118,7 +118,7 @@ read_int(const char *nptr, const char *name) {
 	char *endptr;
 	errno = 0;
 	int64_t value = strtoll(nptr, &endptr, 10);
-	if (nptr[0] == '\0' || *endptr == '\0') {
+	if (nptr[0] == '\0' || *endptr != '\0') {
 		errx(1, "%s is not a number: %s", name, nptr);
 	}
 	if (errno == ERANGE) {


### PR DESCRIPTION
If the entire strtoll() string is a valid integer, endptr is NULL, not non-null. So the reversed check meant that "3" was invalid input, but
"3.3" was valid, and so was "3.hithere" or "3junk".

Now "3.3" is considered invalid, which is fine because unlike some other seq's out there this one doesn't do floating point (and we silently dropped the decimal anyway soooooo...)

More importantly, "3" is actually considered valid.

...

I figured this out and wrote a commit to fix it, then only afterward realized #1 exists. But hopefully this commit is still useful on the grounds that it is simpler, therefore less controversial.